### PR TITLE
Update VoiceChannel when client is moved.

### DIFF
--- a/SharpLink/Enums/SessionChange.cs
+++ b/SharpLink/Enums/SessionChange.cs
@@ -5,5 +5,6 @@
         Connect,
         Disconnect,
         MoveNode,
+        Moved
     }
 }

--- a/SharpLink/LavalinkManager.cs
+++ b/SharpLink/LavalinkManager.cs
@@ -97,6 +97,13 @@ namespace SharpLink
                             players.Remove(oldVoiceState.VoiceChannel.Guild.Id);
                         }
                     }
+                    else if (oldVoiceState.VoiceChannel != null && newVoiceState.VoiceChannel != null && oldVoiceState.VoiceChannel.Id != newVoiceState.VoiceChannel.Id)
+                    {
+                        logger.Log($"VOICE_STATE_UPDATE({newVoiceState.VoiceChannel.Guild.Id}, Moved)", LogSeverity.Debug);
+
+                        // Moved
+                        players[newVoiceState.VoiceChannel.Guild.Id].VoiceChannel = newVoiceState.VoiceChannel;
+                    }
                 }
             };
 

--- a/SharpLink/LavalinkManager.cs
+++ b/SharpLink/LavalinkManager.cs
@@ -97,7 +97,7 @@ namespace SharpLink
                             players.Remove(oldVoiceState.VoiceChannel.Guild.Id);
                         }
                     }
-                    else if (oldVoiceState.VoiceChannel != null && newVoiceState.VoiceChannel != null && oldVoiceState.VoiceChannel.Id != newVoiceState.VoiceChannel.Id)
+                    else if (oldVoiceState.VoiceChannel != null && newVoiceState.VoiceChannel != null && oldVoiceState.VoiceChannel.Id != newVoiceState.VoiceChannel.Id && players[newVoiceState.VoiceChannel.Guild.Id] != null)
                     {
                         logger.Log($"VOICE_STATE_UPDATE({newVoiceState.VoiceChannel.Guild.Id}, Moved)", LogSeverity.Debug);
 

--- a/SharpLink/LavalinkManager.cs
+++ b/SharpLink/LavalinkManager.cs
@@ -85,7 +85,7 @@ namespace SharpLink
                     }
                     else if (oldVoiceState.VoiceChannel != null && newVoiceState.VoiceChannel == null)
                     {
-                        logger.Log($"VOICE_STATE_UPDATE({newVoiceState.VoiceChannel.Guild.Id}, Disconnected)", LogSeverity.Debug);
+                        logger.Log($"VOICE_STATE_UPDATE({oldVoiceState.VoiceChannel.Guild.Id}, Disconnected)", LogSeverity.Debug);
 
                         // Disconnected
                         LavalinkPlayer player = players[oldVoiceState.VoiceChannel.Guild.Id];

--- a/SharpLink/LavalinkManager.cs
+++ b/SharpLink/LavalinkManager.cs
@@ -97,12 +97,17 @@ namespace SharpLink
                             players.Remove(oldVoiceState.VoiceChannel.Guild.Id);
                         }
                     }
-                    else if (oldVoiceState.VoiceChannel != null && newVoiceState.VoiceChannel != null && oldVoiceState.VoiceChannel.Id != newVoiceState.VoiceChannel.Id && players[newVoiceState.VoiceChannel.Guild.Id] != null)
+                    else if (oldVoiceState.VoiceChannel != null && newVoiceState.VoiceChannel != null && oldVoiceState.VoiceChannel.Id != newVoiceState.VoiceChannel.Id)
                     {
                         logger.Log($"VOICE_STATE_UPDATE({newVoiceState.VoiceChannel.Guild.Id}, Moved)", LogSeverity.Debug);
 
                         // Moved
-                        players[newVoiceState.VoiceChannel.Guild.Id].VoiceChannel = newVoiceState.VoiceChannel;
+                        LavalinkPlayer player = players[oldVoiceState.VoiceChannel.Guild.Id];
+
+                        if (player != null)
+                        {
+                            await player.UpdateSessionAsync(SessionChange.Moved, newVoiceState.VoiceChannel);
+                        }
                     }
                 }
             };

--- a/SharpLink/LavalinkPlayer.cs
+++ b/SharpLink/LavalinkPlayer.cs
@@ -16,7 +16,7 @@ namespace SharpLink
         public bool Playing { get; private set; }
         public long CurrentPosition { get; private set; }
         public LavalinkTrack CurrentTrack { get; private set; }
-        public IVoiceChannel VoiceChannel { get; }
+        public IVoiceChannel VoiceChannel { get; internal set; }
         #endregion
 
         internal LavalinkPlayer(LavalinkManager manager, IVoiceChannel voiceChannel)

--- a/SharpLink/LavalinkPlayer.cs
+++ b/SharpLink/LavalinkPlayer.cs
@@ -16,7 +16,7 @@ namespace SharpLink
         public bool Playing { get; private set; }
         public long CurrentPosition { get; private set; }
         public LavalinkTrack CurrentTrack { get; private set; }
-        public IVoiceChannel VoiceChannel { get; internal set; }
+        public IVoiceChannel VoiceChannel { get; private set; }
         #endregion
 
         internal LavalinkPlayer(LavalinkManager manager, IVoiceChannel voiceChannel)
@@ -222,6 +222,13 @@ namespace SharpLink
                         data.Add("guildId", guildId.ToString());
 
                         await manager.GetWebSocket().SendAsync(data.ToString());
+
+                        break;
+                    }
+
+                case SessionChange.Moved:
+                    {
+                        VoiceChannel = (IVoiceChannel)changeData;
 
                         break;
                     }


### PR DESCRIPTION
I have no self esteem, please God don't hurt me if this doesn't work. This is my first pr and I have no idea what I'm doing. LOL (But fo shizzle this should update VoiceChannel inside of LavalinkPlayer so when a user moves the client / bot within a guild we'll get the correct VoiceChannel he's in... or at least that's what is intended)

While it does seem unnecessary for SharpLink, it's actually pretty useful for implementation sake since getting the channel the player is currently in is somewhat important in some cases. =D