### PR TITLE
Fixes for when tracks are replaced, updates to Lavalink config, and fixes for when non-sharded clients get disconnected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,18 @@ A [Lavalink](https://github.com/Frederikam/Lavalink) wrapper for Discord.Net!
 DiscordSocketClient client = new DiscordSocketClient();
 LavalinkManager lavalinkManager = new LavalinkManager(client, new LavalinkManagerConfig
 {
-    ServerAddress = "127.0.0.1",
-    ServerPort = 2333,
+    RESTHost = "localhost",
+    RESTPort = 2333,
+    WebSocketHost = "localhost",
+    WebSocketPort = 2333,
     Authorization = "YOUR_SECRET_AUTHORIZATION_KEY",
     TotalShards = 1 
 });
 ```
 *Notes:* 
 > You don't have to pass a `LavalinkManagerConfig` since Sharplink uses the default config.
+
+> As of Lavalink v3.1, in `LavalinkManagerConfig` your hosts, `RESTHost` and `WebSocketHost`, should be identical, and `RESTPort` should be identical to `WebSocketPort`.
 
 > Set `TotalShards` to the total amount of shards your bot uses. If you don't understand what `TotalShards` is you are probably not sharding your bot and should set this value to `1`.
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,8 @@ A [Lavalink](https://github.com/Frederikam/Lavalink) wrapper for Discord.Net!
 DiscordSocketClient client = new DiscordSocketClient();
 LavalinkManager lavalinkManager = new LavalinkManager(client, new LavalinkManagerConfig
 {
-    RESTHost = "localhost",
-    RESTPort = 2333,
-    WebSocketHost = "localhost",
-    WebSocketPort = 80,
+    ServerAddress = "127.0.0.1",
+    ServerPort = 2333,
     Authorization = "YOUR_SECRET_AUTHORIZATION_KEY",
     TotalShards = 1 
 });

--- a/SharpLink/LavalinkManager.cs
+++ b/SharpLink/LavalinkManager.cs
@@ -400,7 +400,7 @@ namespace SharpLink
         private async Task<JToken> RequestLoadTracksAsync(string identifier)
         {
             DateTime requestTime = DateTime.UtcNow;
-            string response = await client.GetStringAsync($"http://{config.ServerAddress}:{config.ServerPort}/loadtracks?identifier={identifier}");
+            string response = await client.GetStringAsync($"http://{config.RESTHost}:{config.RESTPort}/loadtracks?identifier={identifier}");
             logger.Log($"GET loadtracks: {(DateTime.UtcNow - requestTime).TotalMilliseconds} ms", LogSeverity.Verbose);
 
             JToken json = JToken.Parse(response);

--- a/SharpLink/LavalinkManager.cs
+++ b/SharpLink/LavalinkManager.cs
@@ -89,7 +89,7 @@ namespace SharpLink
                         logger.Log($"VOICE_STATE_UPDATE({oldVoiceState.VoiceChannel.Guild.Id}, Disconnected)", LogSeverity.Debug);
 
                         // Disconnected
-                        if (players.TryGetValue(oldVoiceState.VoiceChannel.Guild.Id, out LavalinkPlayer player))
+                        if (players.TryGetValue(oldVoiceState.VoiceChannel.Guild.Id, out LavalinkPlayer player) && !string.IsNullOrEmpty(player.GetSessionId()))
                         {
                             player.SetSessionId("");
                             await player.UpdateSessionAsync(SessionChange.Disconnect, oldVoiceState.VoiceChannel.Guild.Id);

--- a/SharpLink/LavalinkManager.cs
+++ b/SharpLink/LavalinkManager.cs
@@ -78,9 +78,9 @@ namespace SharpLink
                 {
                     if (oldVoiceState.VoiceChannel == null && newVoiceState.VoiceChannel != null)
                     {
-                        // Connected
                         logger.Log($"VOICE_STATE_UPDATE({newVoiceState.VoiceChannel.Guild.Id}, Connected)", LogSeverity.Debug);
 
+                        // Connected
                         if (players.TryGetValue(newVoiceState.VoiceChannel.Guild.Id, out LavalinkPlayer player))
                             player.SetSessionId(newVoiceState.VoiceSessionId);
                     }

--- a/SharpLink/LavalinkManager.cs
+++ b/SharpLink/LavalinkManager.cs
@@ -78,6 +78,7 @@ namespace SharpLink
                 {
                     if (oldVoiceState.VoiceChannel == null && newVoiceState.VoiceChannel != null)
                     {
+                        // Connected
                         logger.Log($"VOICE_STATE_UPDATE({newVoiceState.VoiceChannel.Guild.Id}, Connected)", LogSeverity.Debug);
 
                         if (players.TryGetValue(newVoiceState.VoiceChannel.Guild.Id, out LavalinkPlayer player))

--- a/SharpLink/LavalinkManagerConfig.cs
+++ b/SharpLink/LavalinkManagerConfig.cs
@@ -5,8 +5,10 @@ namespace SharpLink
     public class LavalinkManagerConfig
     {
         // Default config follows the application.yml.example in the Lavalink GitHub located at https://github.com/Frederikam/Lavalink/blob/master/LavalinkServer/application.yml.example
-        public string ServerAddress = "127.0.0.1";
-        public ushort ServerPort = 2333;
+        public string WebSocketHost = "127.0.0.1";
+        public ushort WebSocketPort = 2333;
+        public string RESTHost = "127.0.0.1";
+        public ushort RESTPort = 2333;
         public string Authorization = "youshallnotpass";
         public int TotalShards = 1;
         public LogSeverity LogSeverity = LogSeverity.Info;

--- a/SharpLink/LavalinkManagerConfig.cs
+++ b/SharpLink/LavalinkManagerConfig.cs
@@ -5,10 +5,8 @@ namespace SharpLink
     public class LavalinkManagerConfig
     {
         // Default config follows the application.yml.example in the Lavalink GitHub located at https://github.com/Frederikam/Lavalink/blob/master/LavalinkServer/application.yml.example
-        public string WebSocketHost = "127.0.0.1";
-        public ushort WebSocketPort = 80;
-        public string RESTHost = "127.0.0.1";
-        public ushort RESTPort = 2333;
+        public string ServerAddress = "127.0.0.1";
+        public ushort ServerPort = 2333;
         public string Authorization = "youshallnotpass";
         public int TotalShards = 1;
         public LogSeverity LogSeverity = LogSeverity.Info;

--- a/SharpLink/LavalinkPlayer.cs
+++ b/SharpLink/LavalinkPlayer.cs
@@ -156,8 +156,9 @@ namespace SharpLink
 
                 case Event.TrackEnd:
                     {
-                        CurrentTrack = null;
-                        Playing = false;
+                        bool replaced = ((string)eventData) == "REPLACED";
+                        CurrentTrack = replaced ? CurrentTrack : null;
+                        Playing = replaced;
 
                         break;
                     }

--- a/SharpLink/LavalinkPlayer.cs
+++ b/SharpLink/LavalinkPlayer.cs
@@ -10,7 +10,6 @@ namespace SharpLink
     public class LavalinkPlayer
     {
         private LavalinkManager manager;
-        private string sessionId = "";
 
         #region PUBLIC_FIELDS
         public bool Playing { get; private set; }
@@ -181,16 +180,6 @@ namespace SharpLink
             }
         }
 
-        internal void SetSessionId(string voiceSessionId)
-        {
-            sessionId = voiceSessionId;
-        }
-
-        internal string GetSessionId()
-        {
-            return sessionId;
-        }
-
         internal async Task UpdateSessionAsync(SessionChange change, object changeData = null)
         {
             switch(change)
@@ -206,7 +195,7 @@ namespace SharpLink
                         JObject data = new JObject();
                         data.Add("op", "voiceUpdate");
                         data.Add("guildId", voiceServer.Guild.Id.ToString());
-                        data.Add("sessionId", sessionId);
+                        data.Add("sessionId", (await VoiceChannel.Guild.GetCurrentUserAsync()).VoiceSessionId);
                         data.Add("event", eventData);
 
                         await manager.GetWebSocket().SendAsync(data.ToString());

--- a/SharpLink/LavalinkPlayer.cs
+++ b/SharpLink/LavalinkPlayer.cs
@@ -10,6 +10,7 @@ namespace SharpLink
     public class LavalinkPlayer
     {
         private LavalinkManager manager;
+        private string sessionId = "";
 
         #region PUBLIC_FIELDS
         public bool Playing { get; private set; }
@@ -180,6 +181,16 @@ namespace SharpLink
             }
         }
 
+        internal void SetSessionId(string voiceSessionId)
+        {
+            sessionId = voiceSessionId;
+        }
+
+        internal string GetSessionId()
+        {
+            return sessionId;
+        }
+
         internal async Task UpdateSessionAsync(SessionChange change, object changeData = null)
         {
             switch(change)
@@ -195,7 +206,7 @@ namespace SharpLink
                         JObject data = new JObject();
                         data.Add("op", "voiceUpdate");
                         data.Add("guildId", voiceServer.Guild.Id.ToString());
-                        data.Add("sessionId", (await VoiceChannel.Guild.GetCurrentUserAsync()).VoiceSessionId);
+                        data.Add("sessionId", sessionId);
                         data.Add("event", eventData);
 
                         await manager.GetWebSocket().SendAsync(data.ToString());

--- a/SharpLink/LavalinkWebSocket.cs
+++ b/SharpLink/LavalinkWebSocket.cs
@@ -26,7 +26,7 @@ namespace SharpLink
         {
             this.manager = manager;
             this.config = config;
-            hostUri = new Uri($"ws://{config.ServerAddress}:{config.ServerPort}");
+            hostUri = new Uri($"ws://{config.WebSocketHost}:{config.WebSocketPort}");
         }
 
         private async Task ConnectWebSocketAsync()

--- a/SharpLink/LavalinkWebSocket.cs
+++ b/SharpLink/LavalinkWebSocket.cs
@@ -26,7 +26,7 @@ namespace SharpLink
         {
             this.manager = manager;
             this.config = config;
-            hostUri = new Uri($"ws://{config.WebSocketHost}:{config.WebSocketPort}");
+            hostUri = new Uri($"ws://{config.ServerAddress}:{config.ServerPort}");
         }
 
         private async Task ConnectWebSocketAsync()


### PR DESCRIPTION
This fixes https://github.com/Devoxin/SharpLink/issues/20

This also fixes when a non-sharded client disconnects, it would modify the players dictionary and throw an exception since we can't modify the dictionary while it is being iterated. This meant the player lock would never release and cause further issues elsewhere when we attempt to wait on the lock to be released.

Also changed some things that you'll see in my notes along with my commits. Mostly just making sure we're not making too many duplicate operations.